### PR TITLE
Add transactional Supabase submission RPC

### DIFF
--- a/src/modules/data/SupabaseService.ts
+++ b/src/modules/data/SupabaseService.ts
@@ -79,7 +79,7 @@ export class SupabaseService {
     const { data, error } = await client.rpc<string>('save_submission_with_coordinates', {
       document_name: payload.documentName,
       form_payload: payload.formData,
-      total_pages: payload.totalPages ?? null,
+      total_pages: payload.totalPages === 0 || payload.totalPages == null ? null : payload.totalPages,
       metadata: payload.metadata ?? null,
       coordinates: coordinatePayload
     });

--- a/src/modules/data/SupabaseService.ts
+++ b/src/modules/data/SupabaseService.ts
@@ -85,7 +85,8 @@ export class SupabaseService {
     });
 
     if (error) {
-      const details = [error.message, error.details, error.hint].filter(Boolean).join(' | ');
+      // Only include safe error information, omitting error.hint
+      const details = [error.message, error.details].filter(Boolean).join(' | ');
       throw new Error(`Failed to persist submission: ${details || 'Unknown error'}`);
     }
 

--- a/src/modules/data/SupabaseService.ts
+++ b/src/modules/data/SupabaseService.ts
@@ -61,26 +61,10 @@ export class SupabaseService {
 
     const client = supabaseClientManager.getClient();
 
-    const submissionInsert = {
-      document_name: payload.documentName,
-      total_pages: payload.totalPages || null,
-      extraction_count: payload.extractions.length,
-      form_payload: payload.formData,
-      metadata: payload.metadata ?? null
-    };
-
-    const { data: submissionData, error: submissionError } = await client
-      .from('form_submissions')
-      .insert(submissionInsert)
-      .select('id')
-      .single();
-
-    if (submissionError || !submissionData) {
-      throw new Error(`Failed to save form submission: ${submissionError?.message ?? 'Unknown error'}`);
-    }
-
-    const coordinateRows = payload.extractions.map(ext => ({
-      submission_id: submissionData.id,
+    // Persisting through a Postgres RPC keeps the submission and coordinate rows in the same
+    // transaction so a failure in either write path rolls everything back. This protects the
+    // downstream review tooling from referencing orphaned submissions.
+    const coordinatePayload = payload.extractions.map(ext => ({
       field_name: ext.fieldName,
       page: ext.page,
       text: ext.text,
@@ -92,17 +76,24 @@ export class SupabaseService {
       document_name: payload.documentName
     }));
 
-    if (coordinateRows.length > 0) {
-      const { error: coordinatesError } = await client
-        .from('extraction_coordinates')
-        .insert(coordinateRows);
+    const { data, error } = await client.rpc<string>('save_submission_with_coordinates', {
+      document_name: payload.documentName,
+      form_payload: payload.formData,
+      total_pages: payload.totalPages ?? null,
+      metadata: payload.metadata ?? null,
+      coordinates: coordinatePayload
+    });
 
-      if (coordinatesError) {
-        throw new Error(`Failed to save coordinate data: ${coordinatesError.message}`);
-      }
+    if (error) {
+      const details = [error.message, error.details, error.hint].filter(Boolean).join(' | ');
+      throw new Error(`Failed to persist submission: ${details || 'Unknown error'}`);
     }
 
-    return submissionData.id;
+    if (!data) {
+      throw new Error('Supabase did not return a submission ID after saving.');
+    }
+
+    return data;
   }
 
   async fetchSubmissionWithCoordinates(submissionId: string): Promise<{ submission: FormSubmissionRow; coordinates: ExtractionCoordinateRow[]; }> {

--- a/supabase/migrations/20250305_save_submission_function.sql
+++ b/supabase/migrations/20250305_save_submission_function.sql
@@ -1,0 +1,83 @@
+-- Supabase migration: transactional submission persistence
+-- Wraps form submission and coordinate inserts in a single database function
+
+create or replace function public.save_submission_with_coordinates(
+  document_name text,
+  form_payload jsonb,
+  total_pages int,
+  metadata jsonb default null,
+  coordinates jsonb default '[]'::jsonb
+)
+returns uuid
+language plpgsql
+as $$
+declare
+  new_submission_id uuid;
+  coordinate_count int;
+begin
+  coordinate_count := case
+    when coordinates is null then 0
+    when jsonb_typeof(coordinates) = 'array' then jsonb_array_length(coordinates)
+    else 0
+  end;
+
+  insert into public.form_submissions (
+    document_name,
+    total_pages,
+    extraction_count,
+    form_payload,
+    metadata
+  )
+  values (
+    document_name,
+    nullif(total_pages, 0),
+    coordinate_count,
+    form_payload,
+    metadata
+  )
+  returning id into new_submission_id;
+
+  if coordinate_count > 0 then
+    insert into public.extraction_coordinates (
+      submission_id,
+      field_name,
+      page,
+      text,
+      x,
+      y,
+      width,
+      height,
+      selection_method,
+      document_name
+    )
+    select
+      new_submission_id,
+      coord.field_name,
+      coord.page,
+      coord.text,
+      coord.x,
+      coord.y,
+      coord.width,
+      coord.height,
+      coord.selection_method,
+      coalesce(coord.document_name, document_name)
+    from jsonb_to_recordset(coordinates) as coord(
+      field_name text,
+      page int,
+      text text,
+      x numeric,
+      y numeric,
+      width numeric,
+      height numeric,
+      selection_method text,
+      document_name text
+    );
+  end if;
+
+  return new_submission_id;
+exception
+  when others then
+    -- Propagate errors so Supabase client surfaces them; transaction will roll back automatically.
+    raise;
+end;
+$$;

--- a/supabase/migrations/20250305_save_submission_function.sql
+++ b/supabase/migrations/20250305_save_submission_function.sql
@@ -30,7 +30,7 @@ begin
   )
   values (
     document_name,
-    nullif(total_pages, 0),
+    total_pages,
     coordinate_count,
     form_payload,
     metadata


### PR DESCRIPTION
## Summary
- add a Postgres stored procedure to save submissions and coordinates in one transaction
- update SupabaseService to call the new RPC and propagate detailed failures
- expand SupabaseService unit tests to cover RPC success and rollback scenarios

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dc65f2505c832986a83a4b75cf971f

## Summary by Sourcery

Add a transactional Supabase RPC for persisting form submissions with coordinates, update SupabaseService to call this function and surface detailed failure messages, and expand unit tests to cover RPC success, rollback, and AppState update behaviors.

New Features:
- Add a Postgres stored procedure (save_submission_with_coordinates) to atomically insert submissions and coordinates.
- Update SupabaseService to invoke the new RPC instead of separate table inserts.

Enhancements:
- Improve error handling to combine RPC error message, details, and hint into a single failure string.
- Prevent orphaned submissions by wrapping writes in a single transaction.

Tests:
- Expand SupabaseService unit tests to mock RPC calls for success and failure scenarios.
- Add tests to verify AppState updates on success and remains unchanged on RPC failure.

Chores:
- Add SQL migration script to define the transactional RPC function.